### PR TITLE
Add support for use with WP_CLI.

### DIFF
--- a/multilanguage.php
+++ b/multilanguage.php
@@ -407,7 +407,7 @@ if ( ! function_exists( 'mltlngg_plugin_load' ) ) {
 			 * or we not on login/logout/ page
 			 * redirect to URL with language code 
 			 */
-			if ( ! is_admin() && ! preg_match( "/\/?\w+\.{1}[a-z]{3,4}/", $_SERVER['REQUEST_URI'] ) )
+			if ( ! is_admin() && ! preg_match( "/\/?\w+\.{1}[a-z]{3,4}/", $_SERVER['REQUEST_URI'] ) && ! defined('WP_CLI'))
 				mltlngg_redirect();
 		}
 	}


### PR DESCRIPTION
Don't redirect if WP_CLI is defined.  This way, you can use the WP_CLI client on the commandline without the plugin trying to redirect all the time.  Allows for more secure automatic updates, cron jobs, etc.